### PR TITLE
DOH Rules size change due to massive amount of additions

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,6 +17,6 @@
 | 5000000-5000033     | MalSilo               | [MalSilo](https://malsilo.gitlab.io/feeds/)                                                          |
 | 7724000-7726000     | 3CORESec              | [Sinkholes Ruleset](https://dtection.io/ruleset)                                                     |
 | 10000000-11999999   | Positive Technologies | [PT Security Attack Detection Team ruleset](https://github.com/ptresearch/AttackDetection#sid-range) |
-| 27995000-27999999   | jpgview               | [DOH Rules](https://raw.githubusercontent.com/jpgpi250/piholemanual/master/DOH/DOH.rules)            |
+| 27990000-27999999   | jpgview               | [DOH Rules](https://raw.githubusercontent.com/jpgpi250/piholemanual/master/DOH/DOH.rules)            |
 | 902200000-906200096 | Abuse.ch              | Abuse.ch                                                                                             |
 


### PR DESCRIPTION
Due to the massive amount of new entries (last week), I wish to request an increase of the reserved sid size allocation:

allocated range: 27995000-27999999
new range: 27990000-27999999