### PR TITLE
The Hunters Ledger: update license note to CC BY 4.0

### DIFF
--- a/allocations.yml
+++ b/allocations.yml
@@ -155,7 +155,7 @@ allocations:
     org: The Hunters Ledger
     name: The Hunters Ledger Detection Feed
     url: https://the-hunters-ledger.com/
-    note: "[The Hunters Ledger](https://the-hunters-ledger.com/) - Community threat-intelligence Suricata feed (CC BY-NC 4.0)"
+    note: "[The Hunters Ledger](https://the-hunters-ledger.com/) - Community threat-intelligence Suricata feed (CC BY 4.0)"
     engine:
       - suricata
     ranges:

--- a/index.md
+++ b/index.md
@@ -3,27 +3,27 @@
 **Mission statement**: a working group to self organize sid ranges for the benefit of users
 
 
-| SID Range           | Organization          | Note                                                                                                               |
-| :-                  | :-                    | :-                                                                                                                 |
-| 1000000-1999999     | local                 | Reserved for Local Use - Put your custom rules in this range to avoid conflicts                                    |
-| 2000000-2103999     | Emerging Threats      | [Emerging Threats Open](https://community.emergingthreats.net/)                                                    |
-| 2200000-2299999     | OISF                  | Suricata Engine Events                                                                                             |
-| 2400000-2609999     | Emerging Threats      | [Emerging Threats Open](https://community.emergingthreats.net/)                                                    |
-| 2610000-2619999     | Travis Green          | [Hunting Ruleset](https://github.com/travisbgreen/hunting-rules)                                                   |
-| 2700000-2799999     | Emerging Threats      | [Emerging Threats](https://doc.emergingthreats.net/bin/view/Main/SidAllocation)                                    |
-| 2800000-2899999     | Emerging Threats      | [Emerging Threats Pro](https://doc.emergingthreats.net/bin/view/Main/SidAllocation)                                |
-| 3000000-3099999     | Corelight             | [Corelight Github](https://github.com/corelight/)                                                                  |
-| 3100000-3199999     | Stamus Networks       | [Stamus Networks Detection](https://stamus-networks.com)                                                           |
-| 3200000-3299999     | DCSO                  | [DCSO CyTec](https://medium.com/@DCSO_CyTec), [DCSO Github](https://github.com/DCSO/suricata-rules)                |
-| 3300000-3399999     | Pawpatrules           | [PAW Patrules](https://pawpatrules.fr/)                                                                            |
-| 3400000-3499999     | Aleksi Bovellan       | [NMAP Ruleset](https://github.com/aleksibovellan/opnsense-suricata-nmaps)                                          |
-| 3500000-3509999     | The Hunters Ledger    | [The Hunters Ledger](https://the-hunters-ledger.com/) - Community threat-intelligence Suricata feed (CC BY-NC 4.0) |
-| 4000000-4099999     | ExtraHop              | [ExtraHop IDS](https://www.extrahop.com/solutions/security/ids/)                                                   |
-| 5000000-5000213     | Etnetera a.s.         | [Etnetera aggressive IP blacklist](https://security.etnetera.cz/feeds/etn_aggressive.rules)                        |
-| 6000000-6099999     | Julioliraup           | [Antiphishing](https://github.com/julioliraup/Antiphishing)                                                        |
-| 9555000-9954999     | Wybot SAS             | [Wybot Cybersecurity](https://www.wybot-cybersecurite.com/)                                                        |
-| 10000000-11999999   | Positive Technologies | [PT Security Attack Detection Team ruleset](https://github.com/ptresearch/AttackDetection#sid-range)               |
-| 12000000-12999999   | IPFire                | [IPFire Domain Block List](https://www.ipfire.org/dbl/)                                                            |
-| 27990000-27999999   | jpgview               | [DOH Rules](https://raw.githubusercontent.com/jpgpi250/piholemanual/master/DOH/DOH.rules)                          |
-| 100000000-199999999 | Emerging Threats      | [Emerging Threats](https://doc.emergingthreats.net/bin/view/Main/SidAllocation)                                    |
-| 902200000-906200096 | Abuse.ch              | Abuse.ch                                                                                                           |
+| SID Range           | Organization          | Note                                                                                                            |
+| :-                  | :-                    | :-                                                                                                              |
+| 1000000-1999999     | local                 | Reserved for Local Use - Put your custom rules in this range to avoid conflicts                                 |
+| 2000000-2103999     | Emerging Threats      | [Emerging Threats Open](https://community.emergingthreats.net/)                                                 |
+| 2200000-2299999     | OISF                  | Suricata Engine Events                                                                                          |
+| 2400000-2609999     | Emerging Threats      | [Emerging Threats Open](https://community.emergingthreats.net/)                                                 |
+| 2610000-2619999     | Travis Green          | [Hunting Ruleset](https://github.com/travisbgreen/hunting-rules)                                                |
+| 2700000-2799999     | Emerging Threats      | [Emerging Threats](https://doc.emergingthreats.net/bin/view/Main/SidAllocation)                                 |
+| 2800000-2899999     | Emerging Threats      | [Emerging Threats Pro](https://doc.emergingthreats.net/bin/view/Main/SidAllocation)                             |
+| 3000000-3099999     | Corelight             | [Corelight Github](https://github.com/corelight/)                                                               |
+| 3100000-3199999     | Stamus Networks       | [Stamus Networks Detection](https://stamus-networks.com)                                                        |
+| 3200000-3299999     | DCSO                  | [DCSO CyTec](https://medium.com/@DCSO_CyTec), [DCSO Github](https://github.com/DCSO/suricata-rules)             |
+| 3300000-3399999     | Pawpatrules           | [PAW Patrules](https://pawpatrules.fr/)                                                                         |
+| 3400000-3499999     | Aleksi Bovellan       | [NMAP Ruleset](https://github.com/aleksibovellan/opnsense-suricata-nmaps)                                       |
+| 3500000-3509999     | The Hunters Ledger    | [The Hunters Ledger](https://the-hunters-ledger.com/) - Community threat-intelligence Suricata feed (CC BY 4.0) |
+| 4000000-4099999     | ExtraHop              | [ExtraHop IDS](https://www.extrahop.com/solutions/security/ids/)                                                |
+| 5000000-5000213     | Etnetera a.s.         | [Etnetera aggressive IP blacklist](https://security.etnetera.cz/feeds/etn_aggressive.rules)                     |
+| 6000000-6099999     | Julioliraup           | [Antiphishing](https://github.com/julioliraup/Antiphishing)                                                     |
+| 9555000-9954999     | Wybot SAS             | [Wybot Cybersecurity](https://www.wybot-cybersecurite.com/)                                                     |
+| 10000000-11999999   | Positive Technologies | [PT Security Attack Detection Team ruleset](https://github.com/ptresearch/AttackDetection#sid-range)            |
+| 12000000-12999999   | IPFire                | [IPFire Domain Block List](https://www.ipfire.org/dbl/)                                                         |
+| 27990000-27999999   | jpgview               | [DOH Rules](https://raw.githubusercontent.com/jpgpi250/piholemanual/master/DOH/DOH.rules)                       |
+| 100000000-199999999 | Emerging Threats      | [Emerging Threats](https://doc.emergingthreats.net/bin/view/Main/SidAllocation)                                 |
+| 902200000-906200096 | Abuse.ch              | Abuse.ch                                                                                                        |


### PR DESCRIPTION
The Hunters Ledger Suricata feed has been relicensed from CC BY-NC 4.0 to **CC BY 4.0** — dropping the non-commercial restriction, so it is now free for anyone including commercial use, with attribution. This updates the `note` on the allocation entry to match. No change to the allocated range (`3500000` / `10000`).
